### PR TITLE
Add option to override the shutdown command

### DIFF
--- a/custom_components/switchbotremote/climate.py
+++ b/custom_components/switchbotremote/climate.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_TEMP_MAX,
     CONF_TEMP_STEP,
     CONF_HVAC_MODES,
+    CONF_OVERRIDE_OFF_COMMAND,
 )
 from .config_flow import DEFAULT_HVAC_MODES
 
@@ -79,6 +80,7 @@ class SwitchBotRemoteClimate(ClimateEntity, RestoreEntity):
         self._max_temp = options.get(CONF_TEMP_MAX, DEFAULT_MAX_TEMP)
         self._min_temp = options.get(CONF_TEMP_MIN, DEFAULT_MIN_TEMP)
         self._power_sensor = options.get(CONF_POWER_SENSOR, None)
+        self._override_off_command = options.get(CONF_OVERRIDE_OFF_COMMAND, True)
 
         self._fan_mode = FAN_AUTO
         self._fan_modes = [
@@ -207,7 +209,7 @@ class SwitchBotRemoteClimate(ClimateEntity, RestoreEntity):
 
     def set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:
+        if hvac_mode == HVACMode.OFF and self._override_off_command:
             self.sb.turn("off")
             self._is_on = False
         else:
@@ -222,7 +224,7 @@ class SwitchBotRemoteClimate(ClimateEntity, RestoreEntity):
         self._update_remote()
 
     def _update_remote(self):
-        if (self._hvac_mode != HVACMode.OFF):
+        if (self._hvac_mode != HVACMode.OFF and self._override_off_command):
             self.sb.command(
                 "setAll",
                 f"{self.target_temperature},{HVAC_REMOTE_MODES[self.hvac_mode]},{FAN_REMOTE_MODES[self.fan_mode]},{self.power_state}",

--- a/custom_components/switchbotremote/config_flow.py
+++ b/custom_components/switchbotremote/config_flow.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_WITH_TEMPERATURE,
     CONF_ON_COMMAND,
     CONF_OFF_COMMAND,
+    CONF_OVERRIDE_OFF_COMMAND,
 )
 
 DEFAULT_HVAC_MODES = [
@@ -77,6 +78,7 @@ STEP_CONFIGURE_DEVICE = {
         vol.Optional(CONF_POWER_SENSOR, description={"suggested_value": x.get(CONF_POWER_SENSOR)}): selector({"entity": {"filter": {"domain": ["binary_sensor", "input_boolean", "light", "sensor", "switch"]}}}),
         vol.Optional(CONF_TEMPERATURE_SENSOR, description={"suggested_value": x.get(CONF_TEMPERATURE_SENSOR)}): selector({"entity": {"filter": {"domain": "sensor"}}}),
         vol.Optional(CONF_HUMIDITY_SENSOR, description={"suggested_value": x.get(CONF_HUMIDITY_SENSOR)}): selector({"entity": {"filter": {"domain": "sensor"}}}),
+        vol.Optional(CONF_OVERRIDE_OFF_COMMAND, default=x.get(CONF_OVERRIDE_OFF_COMMAND, True)): bool,
         vol.Optional(CONF_TEMP_MIN, default=x.get(CONF_TEMP_MIN, 16)): int,
         vol.Optional(CONF_TEMP_MAX, default=x.get(CONF_TEMP_MAX, 30)): int,
         vol.Optional(CONF_TEMP_STEP, default=x.get(CONF_TEMP_STEP, 1.0)): selector({"number": {"min": 0.1, "max": 2.0, "step": 0.1, "mode": "slider"}}),

--- a/custom_components/switchbotremote/const.py
+++ b/custom_components/switchbotremote/const.py
@@ -18,6 +18,7 @@ CONF_WITH_BRIGHTNESS = "with_brightness"
 CONF_WITH_TEMPERATURE = "with_temperature"
 CONF_ON_COMMAND = "on_command"
 CONF_OFF_COMMAND = "off_command"
+CONF_OVERRIDE_OFF_COMMAND = "override_off_command"
 
 """Supported Devices"""
 DIY_AIR_CONDITIONER_TYPE = "DIY Air Conditioner"

--- a/custom_components/switchbotremote/translations/en.json
+++ b/custom_components/switchbotremote/translations/en.json
@@ -49,7 +49,8 @@
 					"with_brightness": "Enable brightness control buttons",
 					"with_temperature": "Enable temperature color buttons",
 					"on_command": "On/Off button name",
-					"off_command": "Name of the Off button in case of independent operation"
+					"off_command": "Name of the Off button in case of independent operation",
+					"override_off_command": "Override the native 'off' command"
 				}
 			}
 		}

--- a/custom_components/switchbotremote/translations/es.json
+++ b/custom_components/switchbotremote/translations/es.json
@@ -49,7 +49,8 @@
 					"with_brightness": "Habilitar botones de control brillo",
 					"with_temperature": "Habilitar botones de color de temperatura",
 					"on_command": "Nombre del botón On/Off",
-					"off_command": "Nombre del botón Off en caso de accionar independiente"
+					"off_command": "Nombre del botón Off en caso de accionar independiente",
+					"override_off_command": "Reemplazar el comando de apagado nativo"
 				}
 			}
 		}

--- a/custom_components/switchbotremote/translations/it.json
+++ b/custom_components/switchbotremote/translations/it.json
@@ -49,7 +49,8 @@
 					"with_brightness": "Abilita i pulsanti di controllo della luminosità",
 					"with_temperature": "Abilita i pulsanti colorati della temperatura",
 					"on_command": "Nome del pulsante di accensione/spegnimento",
-					"off_command": "Nome del pulsante Off in caso di funzionamento indipendente"
+					"off_command": "Nome del pulsante Off in caso di funzionamento indipendente",
+					"override_off_command": "Ignora il comando di spegnimento nativo"
 				}
 			}
 		}


### PR DESCRIPTION
- Add a option to override the `setAll(..., off)` command to `turnOff()` command through confg flow settings
- - Posibility to fix #11 issue