### PR TITLE
Errors and exceptions handling improvement

### DIFF
--- a/custom_components/switchbotremote/client/__init__.py
+++ b/custom_components/switchbotremote/client/__init__.py
@@ -4,6 +4,8 @@ from typing import List
 from .client import SwitchBotClient
 from .remote import Remote
 
+from homeassistant.exceptions import ServiceValidationError
+
 __version__ = "2.3.1"
 
 
@@ -22,4 +24,4 @@ class SwitchBot:
         for remote in self.remotes():
             if remote.id == id:
                 return remote
-        raise ValueError(f"Unknown remote {id}")
+        raise ServiceValidationError(f"Unknown remote {id}")

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -48,7 +48,10 @@ class SwitchBotClient:
 
         if response.status_code != 200:
             _LOGGER.debug(f"Received http error {response.status_code} {response.text}")
-            raise HomeAssistantError(f"SwitchBot API server returns status {response.status_code}")
+            if response.status_code != 500:
+                raise HomeAssistantError(f"SwitchBot API server returns status {response.status_code}")
+            else:
+                raise SwitchbotInternal500Error
 
         response_in_json = humps.decamelize(response.json())
         if response_in_json["status_code"] != 100:
@@ -69,3 +72,6 @@ class SwitchBotClient:
 
     def delete(self, path: str, **kwargs) -> Any:
         return self.request("DELETE", path, **kwargs)
+
+class SwitchbotInternal500Error(HomeAssistantError):
+    """Exception raised if the 500 status error has been received from Switchbot cloud API"""

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -74,11 +74,11 @@ class SwitchBotClient:
                 break
             except SwitchbotInternal500Error:
                 _LOGGER.warning("Caught returned status 500 from SwitchBot API server")
-                _LOGGER.debug(f"tryNumber = {tryNumber}, waiting {DELAY_BETWEEN_TRIES_MS} ms")
+                _LOGGER.debug(f"tryNumber = {tryNumber}, waiting {delayMSBetweenTrials} ms")
                 time.sleep(delayMSBetweenTrials / 1000)
-        
-        if tryNumber >= MAX_TRIES-1:
-            raise SwitchbotInternal500Error(f"Max tries ({MAX_TRIES}) reached")
+        else:
+            # The following exception is only raised if all the request attempts have thrown a 500 error code
+            raise SwitchbotInternal500Error(f"Received multiple ({maxNumberOfTrials}) consecutive 500 errors from SwitchBot API server")
         
         return result
 

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -44,7 +44,7 @@ class SwitchBotClient:
 
         return headers
 
-    def request(self, method: str, path: str, **kwargs) -> Any:
+    def __request(self, method: str, path: str, **kwargs) -> Any:
         url = f"{switchbot_host}/{path}"
         _LOGGER.debug(f"Calling service {url}")
         response = request(method, url, headers=self.headers, **kwargs)
@@ -64,13 +64,13 @@ class SwitchBotClient:
         _LOGGER.debug(f"Call service {url} OK")
         return response_in_json
     
-    def filtered_request(self, method: str, path: str, **kwargs) -> Any:
+    def request(self, method: str, path: str, **kwargs) -> Any:
         """Try to send the request.
         If the server returns a 500 Internal error status, will retry until it succeeds or it passes a threshold of max number of tries.
         Any other error will be thrown."""
         for tryNumber in range(MAX_TRIES):
             try:
-                result = self.request(method, path, **kwargs)
+                result = self.__request(method, path, **kwargs)
                 break
             except SwitchbotInternal500Error:
                 _LOGGER.warning("Caught returned status 500 from SwitchBot API server")
@@ -83,16 +83,16 @@ class SwitchBotClient:
         return result
 
     def get(self, path: str, **kwargs) -> Any:
-        return self.filtered_request("GET", path, **kwargs)
+        return self.request("GET", path, **kwargs)
 
     def post(self, path: str, **kwargs) -> Any:
-        return self.filtered_request("POST", path, **kwargs)
+        return self.request("POST", path, **kwargs)
 
     def put(self, path: str, **kwargs) -> Any:
-        return self.filtered_request("PUT", path, **kwargs)
+        return self.request("PUT", path, **kwargs)
 
     def delete(self, path: str, **kwargs) -> Any:
-        return self.filtered_request("DELETE", path, **kwargs)
+        return self.request("DELETE", path, **kwargs)
 
 class SwitchbotInternal500Error(HomeAssistantError):
     """Exception raised if the 500 status error has been received from Switchbot cloud API"""

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -64,18 +64,18 @@ class SwitchBotClient:
         _LOGGER.debug(f"Call service {url} OK")
         return response_in_json
     
-    def request(self, method: str, path: str, **kwargs) -> Any:
+    def request(self, method: str, path: str, maxNumberOfTrials: int = MAX_TRIES, delayMSBetweenTrials: int = DELAY_BETWEEN_TRIES_MS, **kwargs) -> Any:
         """Try to send the request.
         If the server returns a 500 Internal error status, will retry until it succeeds or it passes a threshold of max number of tries.
         Any other error will be thrown."""
-        for tryNumber in range(MAX_TRIES):
+        for tryNumber in range(maxNumberOfTrials):
             try:
                 result = self.__request(method, path, **kwargs)
                 break
             except SwitchbotInternal500Error:
                 _LOGGER.warning("Caught returned status 500 from SwitchBot API server")
                 _LOGGER.debug(f"tryNumber = {tryNumber}, waiting {DELAY_BETWEEN_TRIES_MS} ms")
-                time.sleep(DELAY_BETWEEN_TRIES_MS / 1000)
+                time.sleep(delayMSBetweenTrials / 1000)
         
         if tryNumber >= MAX_TRIES-1:
             raise SwitchbotInternal500Error(f"Max tries ({MAX_TRIES}) reached")

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -71,7 +71,7 @@ class SwitchBotClient:
         for tryNumber in range(maxNumberOfTrials):
             try:
                 result = self.__request(method, path, **kwargs)
-                break
+                return result
             except SwitchbotInternal500Error:
                 _LOGGER.warning("Caught returned status 500 from SwitchBot API server")
                 _LOGGER.debug(f"tryNumber = {tryNumber}, waiting {delayMSBetweenTrials} ms")
@@ -79,8 +79,6 @@ class SwitchBotClient:
         else:
             # The following exception is only raised if all the request attempts have thrown a 500 error code
             raise SwitchbotInternal500Error(f"Received multiple ({maxNumberOfTrials}) consecutive 500 errors from SwitchBot API server")
-        
-        return result
 
     def get(self, path: str, **kwargs) -> Any:
         return self.request("GET", path, **kwargs)

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -75,7 +75,7 @@ class SwitchBotClient:
             except SwitchbotInternal500Error:
                 _LOGGER.debug(f"Caught 500 from Switchbot servers, tryNumber = {tryNumber}")
                 _LOGGER.debug(f"Waiting {DELAY_BETWEEN_TRIES_MS} ms")
-                time.sleep(DELAY_BETWEEN_TRIES_MS) # TODO : THIS IS PROBABLY A BIG NO-NO
+                time.sleep(DELAY_BETWEEN_TRIES_MS / 1000)
         
         if tryNumber >= MAX_TRIES-1:
             raise SwitchbotInternal500Error(f"Max tries ({MAX_TRIES}) reached")

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -8,6 +8,8 @@ from typing import Any
 import humps
 from requests import request
 
+from homeassistant.exceptions import HomeAssistantError
+
 _LOGGER = logging.getLogger(__name__)
 switchbot_host = "https://api.switch-bot.com/v1.1"
 
@@ -46,12 +48,12 @@ class SwitchBotClient:
 
         if response.status_code != 200:
             _LOGGER.debug(f"Received http error {response.status_code} {response.text}")
-            raise RuntimeError(f"SwitchBot API server returns status {response.status_code}")
+            raise HomeAssistantError(f"SwitchBot API server returns status {response.status_code}")
 
         response_in_json = humps.decamelize(response.json())
         if response_in_json["status_code"] != 100:
             _LOGGER.debug(f"Received error in response {response_in_json}")
-            raise RuntimeError(f'An error occurred: {response_in_json["message"]}')
+            raise HomeAssistantError(f'An error occurred: {response_in_json["message"]}')
 
         _LOGGER.debug(f"Call service {url} OK")
         return response_in_json

--- a/custom_components/switchbotremote/client/client.py
+++ b/custom_components/switchbotremote/client/client.py
@@ -73,8 +73,8 @@ class SwitchBotClient:
                 result = self.request(method, path, **kwargs)
                 break
             except SwitchbotInternal500Error:
-                _LOGGER.debug(f"Caught 500 from Switchbot servers, tryNumber = {tryNumber}")
-                _LOGGER.debug(f"Waiting {DELAY_BETWEEN_TRIES_MS} ms")
+                _LOGGER.warning("Caught returned status 500 from SwitchBot API server")
+                _LOGGER.debug(f"tryNumber = {tryNumber}, waiting {DELAY_BETWEEN_TRIES_MS} ms")
                 time.sleep(DELAY_BETWEEN_TRIES_MS / 1000)
         
         if tryNumber >= MAX_TRIES-1:

--- a/custom_components/switchbotremote/config_flow.py
+++ b/custom_components/switchbotremote/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import selector
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from .client import SwitchBot
 
 from .const import (
@@ -131,8 +132,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         remotes = await hass.async_add_executor_job(switchbot.remotes)
         _LOGGER.debug(f"Found remotes: {remotes}")
         return {"title": data["name"], "remotes": remotes}
-    except:
-        raise InvalidAuth()
+    except Exception as exception:
+        raise ConfigEntryAuthFailed from exception
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -191,8 +192,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         try:
             self.discovered_devices = await self.hass.async_add_executor_job(self.sb.remotes)
-        except:
-            raise InvalidAuth()
+        except Exception as exception:
+            raise ConfigEntryAuthFailed from exception
 
         devices = dict()
         for remote in self.discovered_devices:


### PR DESCRIPTION
This PR aims to fix #36 and to generally improve the exceptions potentially raised by the integration using the Home Assistant exception classes

If the Switchbot servers return a 500 status, the integration will send a warning to the Home Assistant logs.
It will wait 0.5s and will then try to resend the same command.
After 5 consecutive 500 status failures, it will (should ?) abort and raise an error to Home Assistant.