### PR TITLE
Add Japanese translation and correct other language translations

### DIFF
--- a/custom_components/switchbotremote/translations/en.json
+++ b/custom_components/switchbotremote/translations/en.json
@@ -11,9 +11,9 @@
 		"step": {
 			"user": {
 				"data": {
-					"name": "Name of the switchbot Hub - This has to be unique per homeassistant app",
-					"token": "Insert your switchbot developer token",
-					"secret": "Insert your switchbot developer seret"
+					"name": "Name of the SwitchBot Hub - This has to be unique per Home Assistant installation",
+					"token": "Insert your SwitchBot developer token",
+					"secret": "Insert your SwitchBot developer secret"
 				}
 			}
 		}

--- a/custom_components/switchbotremote/translations/es.json
+++ b/custom_components/switchbotremote/translations/es.json
@@ -11,7 +11,7 @@
 		"step": {
 			"user": {
 				"data": {
-					"name": "Nombre del Switchbot Hub: debe ser único para cada aplicación de Homeassistant",
+					"name": "Nombre del SwitchBot Hub: debe ser único para cada aplicación de Home Assistant",
 					"token": "Inserta tu token de desarrollador de SwitchBot",
 					"secret": "Inserta tu código de desarrollador de SwitchBot"
 				}

--- a/custom_components/switchbotremote/translations/it.json
+++ b/custom_components/switchbotremote/translations/it.json
@@ -11,9 +11,9 @@
 		"step": {
 			"user": {
 				"data": {
-					"name": "Nome dello switchbot hub - deve essere unico per installazione di homeassistant",
-					"token": "Inserire il token da sviluppatore di switchbot",
-					"secret": "Inserire il secret da sviluppatore di switchbot"
+					"name": "Nome dello SwitchBot Hub - deve essere unico per installazione di Home Assistant",
+					"token": "Inserire il token da sviluppatore di SwitchBot",
+					"secret": "Inserire il secret da sviluppatore di SwitchBot"
 				}
 			}
 		}

--- a/custom_components/switchbotremote/translations/ja.json
+++ b/custom_components/switchbotremote/translations/ja.json
@@ -1,0 +1,58 @@
+{
+	"config": {
+		"abort": {
+			"already_configured": "デバイスはすでに設定されています"
+		},
+		"error": {
+			"cannot_connect": "接続に失敗しました",
+			"invalid_auth": "認証が無効です",
+			"unknown": "予期せぬエラー"
+		},
+		"step": {
+			"user": {
+				"data": {
+					"name": "SwitchBotハブの名前 - Home Assistantのインストールごとに固有のものである必要があります",
+					"token": "SwitchBotの開発者トークンを入力",
+					"secret": "SwitchBotの開発者シークレットを入力"
+				}
+			}
+		}
+	},
+	"options": {
+		"error": {
+			"cannot_connect": "接続に失敗しました",
+			"invalid_auth": "認証が無効です",
+			"unknown": "予期せぬエラー"
+		},
+		"step": {
+			"init": {
+				"title": "デバイスのカスタマイズ",
+				"description": "設定を変更したいデバイスを選んでください。",
+				"data": {
+					"selected_device": "見つかったデバイス"
+				}
+			},
+			"edit_device": {
+				"title": "デバイスの設定",
+				"data": {
+					"temperature_sensor": "エアコンの実際の温度として使用する温度センサーのID",
+					"humidity_sensor": "エアコンの実際の湿度として使用する湿度センサーのID",
+					"power_sensor": "デバイスの状態を取得するための電源センサーのID",
+					"customize_commands": "ボタンの名前（大文字と小文字を区別）",
+					"hvac_modes": "対応するモード",
+					"temp_min": "最低温度",
+					"temp_max": "最大温度",
+					"temp_step": "温度の変化幅",
+					"with_speed": "ファン速度を有効化する",
+					"with_ion": "「イオン」ボタンを有効化する",
+					"with_timer": "「タイマー」ボタンを有効化する",
+					"with_brightness": "明るさの調節ボタンを有効化する",
+					"with_temperature": "色温度のボタンを有効化する",
+					"on_command": "オン/オフ ボタン名",
+					"off_command": "自立運転時のオフボタン名",
+					"override_off_command": "ネイティブの「off」コマンドを上書きする"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Japanese translation added.

Also, proper noun notations have been changed in all languages.
- "switchbot" and "Switchbot" have been unified into "SwitchBot".
- "homeassistant" and "Homeassistant" have been unified into "Home Assistant".

Additionally, "This has to be unique per Home Assistant **app**" in the English translation was a bit confusing, so I matched it to "This has to be unique per Home Assistant **installation**" in the Italian translation (The other languages have not been changed because I was not sure about them).
