### PR TITLE
Climate : fixing internal server error when setting hvac mode

### DIFF
--- a/custom_components/switchbotremote/climate.py
+++ b/custom_components/switchbotremote/climate.py
@@ -237,7 +237,7 @@ class SwitchBotRemoteClimate(ClimateEntity, RestoreEntity):
         if (self._hvac_mode != HVACMode.OFF and self._override_off_command):
             self.sb.command(
                 "setAll",
-                f"{self.target_temperature},{HVAC_REMOTE_MODES[self.hvac_mode]},{FAN_REMOTE_MODES[self.fan_mode]},{self.power_state}",
+                f"{int(self.target_temperature)},{HVAC_REMOTE_MODES[self.hvac_mode]},{FAN_REMOTE_MODES[self.fan_mode]},{self.power_state}",
             )
 
     @callback

--- a/custom_components/switchbotremote/config_flow.py
+++ b/custom_components/switchbotremote/config_flow.py
@@ -82,7 +82,7 @@ STEP_CONFIGURE_DEVICE = {
         vol.Optional(CONF_OVERRIDE_OFF_COMMAND, default=x.get(CONF_OVERRIDE_OFF_COMMAND, True)): bool,
         vol.Optional(CONF_TEMP_MIN, default=x.get(CONF_TEMP_MIN, 16)): int,
         vol.Optional(CONF_TEMP_MAX, default=x.get(CONF_TEMP_MAX, 30)): int,
-        vol.Optional(CONF_TEMP_STEP, default=x.get(CONF_TEMP_STEP, 1.0)): selector({"number": {"min": 0.1, "max": 2.0, "step": 0.1, "mode": "slider"}}),
+        vol.Optional(CONF_TEMP_STEP, default=x.get(CONF_TEMP_STEP, 1.0)): selector({"number": {"min": 1.0, "max": 5.0, "step": 1.0, "mode": "slider"}}),
         vol.Optional(CONF_HVAC_MODES, description={"suggested_value": x.get(CONF_HVAC_MODES, DEFAULT_HVAC_MODES)}): vol.All(selector({"select": {"multiple": True, "options": HVAC_MODES}})),
         vol.Optional(CONF_CUSTOMIZE_COMMANDS, default=x.get(CONF_CUSTOMIZE_COMMANDS, [])): selector({"select": {"multiple": True, "custom_value": True, "options": []}}),
     }),


### PR DESCRIPTION
This pull request closes #57 

Thanks to [this comment](https://github.com/OpenWonderLabs/SwitchBotAPI/issues/363#issuecomment-2491191092) from @davidsak in [OpenWonderLabs/SwitchBotAPI#363](https://github.com/OpenWonderLabs/SwitchBotAPI/issues/363) :
> setAll with a decimal in the temperature parameter does not seem to work anymore but if called with an integer it does. So for instance, “20.3,5,2,on” does not work but “20,5,2,on” does.

When I force a `int`  cast on ` target_temperature` before sending the request, all `hvac_set_mode` commands seem to work.