### PR TITLE
Document default commands feature for media devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*.idea
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -55,7 +55,25 @@ Supported device:
 
 _All above devices support DIY types and add custom buttons/commands in device settings_
 
-To configure custom/learned buttonsmake sure the name of the button must be exactly as they appear in the app (case sensitive and characters like spaces).
+### Default Commands for Media Devices
+
+Media devices (TV, IPTV, DVD, Speaker, Projector, Set Top Box) come with a set of default commands that are always available:
+
+**Basic Commands** (automatically included):
+- Power control (turn on/off)
+- Volume control (up/down, mute)
+- Channel/Source control (up/down, set specific channel)
+- Playback control (play, pause, stop, next, previous) - *varies by device type*
+
+**Extra Commands** (optional):
+In addition to basic commands, each media device type has a collection of extra commands that you can optionally enable during device configuration. These include:
+- Navigation buttons (menu, back, select, cursor movements)
+- Direct digit selection (0-9)
+- Device-specific functions (fast forward, rewind, guides, etc.)
+
+During device setup, you can select which extra commands you'd like to add to your device. This allows you to customize the available buttons to match your specific device and control needs.
+
+To configure custom/learned buttons, make sure the name of the button must be exactly as they appear in the app (case sensitive and characters like spaces).
 
 ![SwitchBot app device](./docs/app.png "SwitchBot app device")
 

--- a/custom_components/switchbotremote/config_flow.py
+++ b/custom_components/switchbotremote/config_flow.py
@@ -161,9 +161,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(_config_entry):
         """Get options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
@@ -214,14 +214,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for SwitchBot integration."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize SwitchBot options flow."""
-        self.data = config_entry.data
-        self.sb = SwitchBot(
-            token=self.data["token"],
-            secret=self.data["secret"],
-            host=self.data.get("host", switchbot_host)
-        )
         self.discovered_devices = []
         self.selected_device = None
         self.current_device_type = None
@@ -238,8 +232,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             _LOGGER.debug(f"Selected device: {self.selected_device}, Type: {self.current_device_type}")
             return await self.async_step_edit_device()
 
+        data = self.config_entry.data
+        sb = SwitchBot(
+            token=data["token"],
+            secret=data["secret"],
+            host=data.get("host", switchbot_host)
+        )
         try:
-            self.discovered_devices = await self.hass.async_add_executor_job(self.sb.remotes)
+            self.discovered_devices = await self.hass.async_add_executor_job(sb.remotes)
             _LOGGER.debug(f"Discovered devices: {self.discovered_devices}")
         except Exception as exception:
             _LOGGER.error(f"Failed to discover devices: {exception}")

--- a/custom_components/switchbotremote/const.py
+++ b/custom_components/switchbotremote/const.py
@@ -157,3 +157,193 @@ IR_WATER_HEATER_TYPES = [
     DIY_WATER_HEATER_TYPE,
     WATER_HEATER_TYPE,
 ]
+
+# This codes and commands specially the test ones are obtained from:
+
+
+MEDIA_PLAYER_COMMANDS = {
+    TV_TYPE: {
+        "basic": {
+            "turn_on": {"action": "turnOn", "customize": False},
+            "turn_off": {"action": "turnOff", "customize": False},
+            "volume_up": {"action": "volumeAdd", "customize": False},
+            "volume_down": {"action": "volumeSub", "customize": False},
+            "channel_up": {"action": "channelAdd", "customize": False},
+            "channel_down": {"action": "channelSub", "customize": False},
+            "set_channel": {"action": "SetChannel", "customize": False},
+            "mute": {"action": "13", "customize": True, "icon": "mdi:volume-mute"},
+
+        },
+        "extra": {
+            "menu": {"action": "5", "customize": True, "icon": "mdi:menu"},
+            "back": {"action": "39", "customize": True, "icon": "mdi:arrow-left"},
+            "select": {"action": "41", "customize": True, "icon": "mdi:check"},
+            "cursor_up": {"action": "43", "customize": True, "icon": "mdi:arrow-up"},
+            "cursor_down": {"action": "49", "customize": True, "icon": "mdi:arrow-down"},
+            "cursor_left": {"action": "45", "customize": True, "icon": "mdi:arrow-left"},
+            "cursor_right": {"action": "47", "customize": True, "icon": "mdi:arrow-right"},
+            "digit_1": {"action": "15", "customize": True, "icon": "mdi:numeric-1-box"},
+            "digit_2": {"action": "17", "customize": True, "icon": "mdi:numeric-2-box"},
+            "digit_3": {"action": "19", "customize": True, "icon": "mdi:numeric-3-box"},
+            "digit_4": {"action": "21", "customize": True, "icon": "mdi:numeric-4-box"},
+            "digit_5": {"action": "23", "customize": True, "icon": "mdi:numeric-5-box"},
+            "digit_6": {"action": "25", "customize": True, "icon": "mdi:numeric-6-box"},
+            "digit_7": {"action": "27", "customize": True, "icon": "mdi:numeric-7-box"},
+            "digit_8": {"action": "29", "customize": True, "icon": "mdi:numeric-8-box"},
+            "digit_9": {"action": "31", "customize": True, "icon": "mdi:numeric-9-box"},
+            "digit_0": {"action": "35", "customize": True, "icon": "mdi:numeric-0-box"},
+            "source_av_tv": {"action": "37", "customize": True, "icon": "mdi:television-classic"},
+            "reset": {"action": "33", "customize": True, "icon": "mdi:restart"},
+        }
+    },
+    IPTV_TYPE: {
+        "basic": {
+            "turn_on": {"action": "turnOn", "customize": False},
+            "turn_off": {"action": "turnOff", "customize": False},
+            "volume_up": {"action": "volumeAdd", "customize": False},
+            "volume_down": {"action": "volumeSub", "customize": False},
+            "channel_up": {"action": "channelAdd", "customize": False},
+            "channel_down": {"action": "channelSub", "customize": False},
+            "set_channel": {"action": "SetChannel", "customize": False},
+            "play": {"action": "23", "customize": True},
+            "mute": {"action": "3", "customize": True, "icon": "mdi:volume-mute"},
+
+        },
+        "extra": {
+            "cursor_up": {"action": "13", "customize": True, "icon": "mdi:arrow-up"},
+            "cursor_left": {"action": "15", "customize": True, "icon": "mdi:arrow-left"},
+            "select": {"action": "17", "customize": True, "icon": "mdi:check"},
+            "cursor_right": {"action": "19", "customize": True, "icon": "mdi:arrow-right"},
+            "cursor_down": {"action": "21", "customize": True, "icon": "mdi:arrow-down"},
+            "back": {"action": "45", "customize": True, "icon": "mdi:arrow-left"},
+            "digit_1": {"action": "25", "customize": True, "icon": "mdi:numeric-1-box"},
+            "digit_2": {"action": "27", "customize": True, "icon": "mdi:numeric-2-box"},
+            "digit_3": {"action": "29", "customize": True, "icon": "mdi:numeric-3-box"},
+            "digit_4": {"action": "31", "customize": True, "icon": "mdi:numeric-4-box"},
+            "digit_5": {"action": "33", "customize": True, "icon": "mdi:numeric-5-box"},
+            "digit_6": {"action": "35", "customize": True, "icon": "mdi:numeric-6-box"},
+            "digit_7": {"action": "37", "customize": True, "icon": "mdi:numeric-7-box"},
+            "digit_8": {"action": "39", "customize": True, "icon": "mdi:numeric-8-box"},
+            "digit_9": {"action": "41", "customize": True, "icon": "mdi:numeric-9-box"},
+            "digit_0": {"action": "43", "customize": True, "icon": "mdi:numeric-0-box"},
+        }
+    },
+    SET_TOP_BOX_TYPE: {
+        "basic": {
+            "turn_on": {"action": "turnOn", "customize": False},
+            "turn_off": {"action": "turnOff", "customize": False},
+            "volume_up": {"action": "volumeAdd", "customize": False},
+            "volume_down": {"action": "volumeSub", "customize": False},
+            "channel_up": {"action": "channelAdd", "customize": False},
+            "channel_down": {"action": "channelSub", "customize": False},
+            "set_channel": {"action": "SetChannel", "customize": False},
+        },
+        "extra": {
+            "standby": {"action": "1", "customize": True, "icon": "mdi:power-standby"},
+            "menu": {"action": "45", "customize": True, "icon": "mdi:menu"},
+            "back": {"action": "25", "customize": True, "icon": "mdi:arrow-left"},
+            "select": {"action": "31", "customize": True, "icon": "mdi:check"},
+            "cursor_up": {"action": "27", "customize": True, "icon": "mdi:arrow-up"},
+            "cursor_left": {"action": "29", "customize": True, "icon": "mdi:arrow-left"},
+            "cursor_right": {"action": "33", "customize": True, "icon": "mdi:arrow-right"},
+            "cursor_down": {"action": "35", "customize": True, "icon": "mdi:arrow-down"},
+            "guide": {"action": "21", "customize": True, "icon": "mdi:television-guide"},
+            "digit_1": {"action": "3", "customize": True, "icon": "mdi:numeric-1-box"},
+            "digit_2": {"action": "5", "customize": True, "icon": "mdi:numeric-2-box"},
+            "digit_3": {"action": "7", "customize": True, "icon": "mdi:numeric-3-box"},
+            "digit_4": {"action": "9", "customize": True, "icon": "mdi:numeric-4-box"},
+            "digit_5": {"action": "11", "customize": True, "icon": "mdi:numeric-5-box"},
+            "digit_6": {"action": "13", "customize": True, "icon": "mdi:numeric-6-box"},
+            "digit_7": {"action": "15", "customize": True, "icon": "mdi:numeric-7-box"},
+            "digit_8": {"action": "17", "customize": True, "icon": "mdi:numeric-8-box"},
+            "digit_9": {"action": "19", "customize": True, "icon": "mdi:numeric-9-box"},
+            "digit_0": {"action": "23", "customize": True, "icon": "mdi:numeric-0-box"},
+        }
+    },
+    DVD_TYPE: {
+        "basic": {
+            "turn_on": {"action": "turnOn", "customize": False},
+            "turn_off": {"action": "turnOff", "customize": False},
+            "play": {"action": "Play", "customize": False},
+            "pause": {"action": "Pause", "customize": False},
+            "stop": {"action": "Stop", "customize": False},
+            "next_track": {"action": "Next", "customize": False},
+            "previous_track": {"action": "Previous", "customize": False},
+            "mute": {"action": "setMute", "customize": False, "icon": "mdi:volume-mute"},
+
+        },
+        "extra": {
+            "fast_forward": {"action": "FastForward", "customize": False, "icon": "mdi:fast-forward"},
+            "rewind": {"action": "Rewind", "customize": False, "icon": "mdi:rewind"},
+            "menu": {"action": "35", "customize": True, "icon": "mdi:menu"},
+            "back": {"action": "37", "customize": True, "icon": "mdi:arrow-left"},
+            "select": {"action": "5", "customize": True, "icon": "mdi:check"},
+            "cursor_up": {"action": "3", "customize": True, "icon": "mdi:arrow-up"},
+            "cursor_left": {"action": "1", "customize": True, "icon": "mdi:arrow-left"},
+            "cursor_right": {"action": "9", "customize": True, "icon": "mdi:arrow-right"},
+            "cursor_down": {"action": "7", "customize": True, "icon": "mdi:arrow-down"},
+            "title": {"action": "31", "customize": True, "icon": "mdi:format-title"},
+            "skip": {"action": "33", "customize": True, "icon": "mdi:skip-forward"},
+            "format": {"action": "27", "customize": True, "icon": "mdi:format-align-center"},
+        }
+    },
+    SPEAKER_TYPE: {
+        "basic": {
+            "turn_on": {"action": "turnOn", "customize": False},
+            "turn_off": {"action": "turnOff", "customize": False},
+            "play": {"action": "Play", "customize": False},
+            "pause": {"action": "Pause", "customize": False},
+            "stop": {"action": "Stop", "customize": False},
+            "next_track": {"action": "Next", "customize": False},
+            "previous_track": {"action": "Previous", "customize": False},
+            "volume_up": {"action": "volumeAdd", "customize": False},
+            "volume_down": {"action": "volumeSub", "customize": False},
+            "mute": {"action": "setMute", "customize": False, "icon": "mdi:volume-mute"},
+
+        },
+        "extra": {
+            "select": {"action": "5", "customize": True, "icon": "mdi:check"},
+            "cursor_up": {"action": "3", "customize": True, "icon": "mdi:arrow-up"},
+            "cursor_left": {"action": "1", "customize": True, "icon": "mdi:arrow-left"},
+            "cursor_right": {"action": "9", "customize": True, "icon": "mdi:arrow-right"},
+            "cursor_down": {"action": "7", "customize": True, "icon": "mdi:arrow-down"},
+            "AudioP": {"action": "13", "customize": True, "icon": "mdi:format-title"},
+            "AudioM": {"action": "17", "customize": True, "icon": "mdi:format-title"},
+            "fast_forward": {"action": "FastForward", "customize": False, "icon": "mdi:fast-forward"},
+            "rewind": {"action": "Rewind", "customize": False, "icon": "mdi:rewind"},
+            "menu": {"action": "33", "customize": True, "icon": "mdi:menu"},
+            "back": {"action": "35", "customize": True, "icon": "mdi:arrow-left"},
+        }
+    },
+    PROJECTOR_TYPE: {
+        "basic": {
+            "turn_on": {"action": "turnOn", "customize": False},
+            "turn_off": {"action": "turnOff", "customize": False},
+            "play": {"action": "21", "customize": True},  # Assuming Select as play/pause toggle
+            "pause": {"action": "21", "customize": True},
+            "volume_up": {"action": "33", "customize": True},
+            "volume_down": {"action": "35", "customize": True},
+            "mute": {"action": "37", "customize": True, "icon": "mdi:volume-mute"},
+
+        },
+        "extra": {
+            "source_computer": {"action": "5", "customize": True, "icon": "mdi:laptop"}, # Not working on test device
+            "source_video": {"action": "7", "customize": True, "icon": "mdi:video"}, # Not working on test device
+            "source_signal": {"action": "9", "customize": True, "icon": "mdi:signal"}, # Not working on test device
+            "menu": {"action": "19", "customize": True, "icon": "mdi:menu"},
+            "select": {"action": "21", "customize": True, "icon": "mdi:check"},
+            "cursor_up": {"action": "23", "customize": True, "icon": "mdi:arrow-up"},
+            "cursor_left": {"action": "25", "customize": True, "icon": "mdi:arrow-left"},
+            "cursor_right": {"action": "27", "customize": True, "icon": "mdi:arrow-right"},
+            "cursor_down": {"action": "29", "customize": True, "icon": "mdi:arrow-down"},
+            "exit": {"action": "31", "customize": True, "icon": "mdi:exit-to-app"},
+            "auto": {"action": "39", "customize": True, "icon": "mdi:auto-fix"}, # Not working on test device
+            "focus_in": {"action": "11", "customize": True, "icon": "mdi:magnify-plus"}, # Not working on test device
+            "focus_out": {"action": "13", "customize": True, "icon": "mdi:magnify-minus"}, # Not working on test device
+            "picture_up": {"action": "15", "customize": True, "icon": "mdi:image-plus"}, # Not working on test device
+            "picture_down": {"action": "17", "customize": True, "icon": "mdi:image-minus"}, # Not working on test device
+            "mode": {"action": "43", "customize": True, "icon": "mdi:projector-screen"}, # Not working on test device
+            # pause": {"action": "41", "customize": True},Assuming PJT_Pause as play/pause toggle # Not working on test device
+        }
+    }
+}

--- a/custom_components/switchbotremote/fan.py
+++ b/custom_components/switchbotremote/fan.py
@@ -147,7 +147,7 @@ class SwitchBotRemoteFan(FanEntity, RestoreEntity):
         await self.async_set_percentage(percentage)
 
     async def async_turn_off(self, **kwargs):
-        """Send the power on command."""
+        """Send the power off command."""
         await self.send_command("turnOff")
         self._state = STATE_OFF
         self._is_on = False

--- a/custom_components/switchbotremote/media_player.py
+++ b/custom_components/switchbotremote/media_player.py
@@ -16,21 +16,20 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from .client.remote import SupportedRemote
 
-from .const import DOMAIN, MEDIA_CLASS, IR_MEDIA_TYPES, DIY_PROJECTOR_TYPE, PROJECTOR_TYPE, CONF_POWER_SENSOR
+from .const import DOMAIN, MEDIA_CLASS, IR_MEDIA_TYPES, DIY_PROJECTOR_TYPE, PROJECTOR_TYPE, CONF_POWER_SENSOR, \
+    MEDIA_PLAYER_COMMANDS, DIY_DVD_TYPE, DVD_TYPE, DIY_SPEAKER_TYPE, SPEAKER_TYPE, TV_TYPE, IPTV_TYPE, DIY_IPTV_TYPE, \
+    DIY_TV_TYPE, SET_TOP_BOX_TYPE, DIY_SET_TOP_BOX_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
-IR_TRACK_TYPES = [
-    'DIY DVD',
-    'DVD',
-    'DIY Speaker',
-    'Speaker',
-]
+IR_DVD_TYPES = [DVD_TYPE, DIY_DVD_TYPE]
+IR_SPEAKER_TYPES = [SPEAKER_TYPE, DIY_SPEAKER_TYPE]
 
-IR_PROJECTOR_TYPES = [
-    DIY_PROJECTOR_TYPE,
-    PROJECTOR_TYPE,
-]
+IR_TV_TYPES = [TV_TYPE, DIY_TV_TYPE]
+IR_IPTV_TYPES = [DIY_IPTV_TYPE, IPTV_TYPE]
+IR_PROJECTOR_TYPES = [DIY_PROJECTOR_TYPE, PROJECTOR_TYPE]
+IR_SET_TOP_BOX_TYPES = [SET_TOP_BOX_TYPE, DIY_SET_TOP_BOX_TYPE]
+
 
 
 class SwitchbotRemoteMediaPlayer(MediaPlayerEntity, RestoreEntity):
@@ -48,26 +47,34 @@ class SwitchbotRemoteMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         self._power_sensor = options.get(CONF_POWER_SENSOR, None)
 
+        # Define supported features based on device type
         self._supported_features = MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.TURN_OFF
-        self._supported_features |= MediaPlayerEntityFeature.VOLUME_STEP
-        self._supported_features |= MediaPlayerEntityFeature.VOLUME_MUTE
-        self._supported_features |= MediaPlayerEntityFeature.PLAY_MEDIA
 
-        if (sb.type in IR_TRACK_TYPES):
+        if not (sb.type in IR_DVD_TYPES):
+            self._supported_features |= MediaPlayerEntityFeature.VOLUME_STEP
+
+        if not (sb.type in IR_SET_TOP_BOX_TYPES):
+            self._supported_features |= MediaPlayerEntityFeature.VOLUME_MUTE
+
+        if sb.type in IR_IPTV_TYPES or sb.type in IR_TV_TYPES or sb.type in IR_SET_TOP_BOX_TYPES:
+            self._supported_features |= MediaPlayerEntityFeature.VOLUME_STEP
+            self._supported_features |= MediaPlayerEntityFeature.PLAY_MEDIA
+
+        if sb.type in IR_IPTV_TYPES or sb.type in IR_DVD_TYPES or sb.type in IR_SPEAKER_TYPES or sb.type in IR_PROJECTOR_TYPES:
             self._supported_features |= MediaPlayerEntityFeature.PLAY
-            self._supported_features |= MediaPlayerEntityFeature.PAUSE
+            if not (sb.type in IR_IPTV_TYPES):
+                self._supported_features |= MediaPlayerEntityFeature.PAUSE
+
+        if sb.type in IR_DVD_TYPES or sb.type in IR_SPEAKER_TYPES:
             self._supported_features |= MediaPlayerEntityFeature.PREVIOUS_TRACK
             self._supported_features |= MediaPlayerEntityFeature.NEXT_TRACK
             self._supported_features |= MediaPlayerEntityFeature.STOP
-        elif (sb.type in IR_PROJECTOR_TYPES):
-            self._supported_features |= MediaPlayerEntityFeature.PLAY
-            self._supported_features |= MediaPlayerEntityFeature.PAUSE
-        else:
-            self._supported_features |= MediaPlayerEntityFeature.PREVIOUS_TRACK
-            self._supported_features |= MediaPlayerEntityFeature.NEXT_TRACK
-            self._supported_features |= MediaPlayerEntityFeature.SELECT_SOURCE
+
+        # Load basic commands for this device type
+        self._commands = MEDIA_PLAYER_COMMANDS.get(sb.type, {}).get("basic", {})
 
     async def send_command(self, *args):
+        """Send a command using the SupportedRemote's command method."""
         await self._hass.async_add_executor_job(self.sb.command, *args)
 
     @property
@@ -104,145 +111,145 @@ class SwitchbotRemoteMediaPlayer(MediaPlayerEntity, RestoreEntity):
         """Return the state of the player."""
         return self._state
 
-    async def async_turn_off(self):
-        """Turn the media player off."""
-        await self.send_command("turnOff")
-
-        self._state = STATE_OFF
-        self._source = None
-
-        self.async_write_ha_state()
 
     async def async_turn_on(self):
+        """Turn the media player on."""
+        command_info = self._commands.get("turn_on")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self._state = STATE_IDLE if (self.sb.type in IR_SPEAKER_TYPES or self.sb.type in IR_DVD_TYPES) else STATE_ON
+            self.async_write_ha_state()
+
+
+    async def async_turn_off(self):
         """Turn the media player off."""
-        await self.send_command("turnOn")
+        command_info = self._commands.get("turn_off")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self._state = STATE_OFF
+            self._source = None
+            self.async_write_ha_state()
 
-        self._state = STATE_IDLE if self.sb.type in IR_TRACK_TYPES else STATE_ON
-        self.async_write_ha_state()
-
-    async def async_media_previous_track(self):
-        """Send previous track command."""
-        if self.sb.type in IR_TRACK_TYPES:
-            await self.send_command("Previous")
-        else:
-            await self.send_command("channelSub")
-        self.async_write_ha_state()
-
-    async def async_media_next_track(self):
-        """Send next track command."""
-        await self.send_command("Next")
-        if self.sb.type in IR_TRACK_TYPES:
-            await self.send_command("Next")
-        else:
-            await self.send_command("channelAdd")
-        self.async_write_ha_state()
-
-    async def async_volume_down(self):
-        """Turn volume down for media player."""
-        if self.sb.type in IR_PROJECTOR_TYPES:
-            await self.send_command("VOL-", None, True)
-        else:
-            await self.send_command("volumeSub")
-
-        self.async_write_ha_state()
 
     async def async_volume_up(self):
         """Turn volume up for media player."""
-        if self.sb.type in IR_PROJECTOR_TYPES:
-            await self.send_command("VOL+", None, True)
-        else:
-            await self.send_command("volumeAdd")
+        command_info = self._commands.get("volume_up")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
 
-        self.async_write_ha_state()
+
+    async def async_volume_down(self):
+        """Turn volume down for media player."""
+        command_info = self._commands.get("volume_down")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
+
 
     async def async_mute_volume(self, mute):
         """Mute the volume."""
-        if self.sb.type in IR_PROJECTOR_TYPES:
-            await self.send_command("MUTE", None, True)
-        else:
-            await self.send_command("setMute")
+        command_info = self._commands.get("mute")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
 
-        self.async_write_ha_state()
 
     async def async_media_play(self):
-        """Play/Resume media"""
-        self._state = STATE_PLAYING
+        """Play/Resume media."""
+        command_info = self._commands.get("play")
+        if command_info:
+            self._state = STATE_PLAYING
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
 
-        if self.sb.type in IR_PROJECTOR_TYPES:
-            await self.send_command("PLAY", None, True)
-        else:
-            await self.send_command("Play")
-
-        self.async_write_ha_state()
 
     async def async_media_pause(self):
-        """Pause media"""
-        self._state = STATE_PAUSED
+        """Pause media."""
+        command = "play" if self.sb.type in IR_IPTV_TYPES else "pause"
+        command_info = self._commands.get(command)
+        if command_info:
+            self._state = STATE_PAUSED
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
 
-        if self.sb.type in IR_PROJECTOR_TYPES:
-            await self.send_command("Paused", None, True)
-        else:
-            await self.send_command("Pause")
-
-        self.async_write_ha_state()
 
     async def async_media_play_pause(self):
-        """Play/Pause media"""
-        self._state = STATE_PLAYING
-        await self.send_command("Play")
-        self.async_write_ha_state()
+        if self._state:
+            await self.async_media_pause()
+        else:
+            await self.async_media_play()
+
 
     async def async_media_stop(self):
-        """Stop media"""
-        self._state = STATE_IDLE
-        await self.send_command("Stop")
-        self.async_write_ha_state()
+        """Stop media."""
+        command_info = self._commands.get("stop")
+        if command_info:
+            self._state = STATE_IDLE
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
+
+
+    async def async_media_next_track(self):
+        """Send next track command."""
+        command_info = self._commands.get("next_track")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
+
+
+    async def async_media_previous_track(self):
+        """Send previous track command."""
+        command_info = self._commands.get("previous_track")
+        if command_info:
+            await self.send_command(command_info["action"], None, command_info["customize"])
+            self.async_write_ha_state()
+
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Support channel change through play_media service."""
         if self._state == STATE_OFF:
             await self.async_turn_on()
 
-        if not media_id.isdigit():
-            _LOGGER.error("media_id must be a channel number")
-            return
+        if media_type == "channel" and "set_channel" in self._commands:
+            if not media_id.isdigit():
+                _LOGGER.error("media_id must be a channel number")
+                return
+            command_info = self._commands["set_channel"]
+            await self.send_command(command_info["action"], media_id, command_info["customize"])
+            self._source = f"Channel {media_id}"
+            self.async_write_ha_state()
 
-        self._source = "Channel {}".format(media_id)
-        for digit in media_id:
-            await self.send_command("SetChannel", digit, True)
-        self.async_write_ha_state()
 
     @callback
     def _async_update_power(self, state):
-        """Update thermostat with latest state from temperature sensor."""
+        """Update state based on power sensor."""
         try:
             if state.state != STATE_UNKNOWN and state.state != STATE_UNAVAILABLE:
                 if state.state == STATE_OFF:
                     self._state = STATE_OFF
                     self._source = None
                 elif state.state == STATE_ON:
-                    self._state = STATE_IDLE if self.sb.type in IR_TRACK_TYPES else STATE_ON
-
+                    self._state = STATE_IDLE if (self.sb.type in IR_DVD_TYPES or self.sb.type in IR_SPEAKER_TYPES) else STATE_ON
         except ValueError as ex:
             _LOGGER.error("Unable to update from power sensor: %s", ex)
+
 
     async def _async_power_sensor_changed(self, event: Event):
         """Handle power sensor changes."""
         new_state = event.data.get('new_state')
         if new_state is None:
             return
-
         self._async_update_power(new_state)
         self.async_write_ha_state()
+
 
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
-
         if self._power_sensor:
             async_track_state_change_event(
                 self.hass, [self._power_sensor], self._async_power_sensor_changed)
-
             power_sensor_state = self.hass.states.get(self._power_sensor)
             if power_sensor_state and power_sensor_state.state != STATE_UNKNOWN:
                 self._async_update_power(power_sensor_state)
@@ -250,12 +257,9 @@ class SwitchbotRemoteMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> bool:
     remotes = hass.data[DOMAIN][entry.entry_id]
-
     entities = [
         SwitchbotRemoteMediaPlayer(hass, remote, entry.data.get(remote.id, {}))
         for remote in filter(lambda r: r.type in IR_MEDIA_TYPES, remotes)
     ]
-
     async_add_entities(entities)
-
     return True


### PR DESCRIPTION
## Summary

- Adds comprehensive documentation for the new media device default commands feature
- Explains the difference between basic commands (always included) and extra commands (optional)
- Guides users on how to customize media device buttons during device setup

## Details

This PR includes:
- Documentation in README explaining default commands structure for media devices (TV, IPTV, DVD, Speaker, Projector, Set Top Box)
- Clear breakdown of basic vs extra commands
- Instructions for users on how to select optional extra commands during configuration

## Testing

Users can now understand how the default commands feature works and how to customize their media devices through the config flow.