### PR TITLE
Fix fan not being able to turn on/off

### DIFF
--- a/custom_components/switchbotremote/fan.py
+++ b/custom_components/switchbotremote/fan.py
@@ -62,12 +62,12 @@ class SwitchBotRemoteFan(FanEntity, RestoreEntity):
             if sb.type in IR_AIR_PURIFIER_TYPES
             else SPEED_COMMANDS[0]
         )
-        self._supported_features = 0
+        self._supported_features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
 
         self._power_sensor = options.get(CONF_POWER_SENSOR, None)
 
         if options.get(CONF_WITH_SPEED, None):
-            self._supported_features = FanEntityFeature.SET_SPEED
+            self._supported_features |= FanEntityFeature.SET_SPEED
 
         if sb.type not in IR_AIR_PURIFIER_TYPES:
             self._supported_features |= FanEntityFeature.OSCILLATE


### PR DESCRIPTION
In Home Assistant 2024.8, `TURN_ON` and `TURN_OFF` have been added to the feature flags. Implementing the turn on/off methods without setting these flags have been deprecated in 2025.2, resulting in an error message when toggling the power from the device's control menu.

I tested this on my device and confirmed that the fan can now be turned on/off through the control UI.

Reference:
- https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/

Fixes #63.

Note, in the above issue @sam-cheuk suggested another bug fix regarding `SET_SPEED` but I didn’t incorporate that into this PR because I did not experience this issue (probably because of the type of fan I am using).